### PR TITLE
allow css customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,25 @@ export default {
 };
 ```
 
+### Customizing appearance
+
+You can provide classes to customize each of the three components -- Compiler (displays), Editor, and Error -- by passing `useView` `compilerClassName`, `editorClassName`, and `errorClassName` props respectively.
+
+```jsx
+
+export default {
+  title: "Component",
+  component: Component,
+  decorators: [withReactView],
+  parameters: { useView: { 
+    scope: { Component, ABC, myFun }
+    compilerClassName: "compiler-class",
+    editorClassName: "editor-class",
+    errorClassName: "error-class",
+  } },
+};
+```
+
 ## License
 
 [MIT](./LICENSE)

--- a/src/register.tsx
+++ b/src/register.tsx
@@ -1,11 +1,23 @@
 import React from "react";
-import { useView, Compiler, Editor, Error } from "react-view";
+import { useView, Compiler, Editor, Error, TUseViewParams } from "react-view";
 
 import { makeDecorator, StoryContext, StoryFn } from "@storybook/addons";
 
 import { renderJsx } from "./renderJsx";
 
-const Preview = ({ storyFn, storyContext, parameters }: any) => {
+interface ExtendedParameters extends TUseViewParams {
+  compilerClassName?: string;
+  editorClassName?: string;
+  errorClassName?: string;
+}
+
+interface PreviewProps {
+  storyFn: any;
+  storyContext: any;
+  parameters: ExtendedParameters;
+}
+
+const Preview = ({ storyFn, storyContext, parameters }: PreviewProps) => {
   let initialCode = "";
 
   if (
@@ -18,17 +30,19 @@ const Preview = ({ storyFn, storyContext, parameters }: any) => {
     initialCode = `() => (\n` + renderJsx(storyFn(storyContext), {}) + `\n);`;
   }
 
+  const { compilerClassName, editorClassName, errorClassName, ...config } = parameters
+
   const params = useView({
-    ...parameters,
+    ...config,
     initialCode,
   });
 
   return (
     <React.Fragment>
-      <Compiler {...params.compilerProps} />
+      <Compiler {...params.compilerProps} className={compilerClassName} />
       <div style={{ marginTop: 20 }}>
-        <Editor {...params.editorProps} />
-        <Error {...params.errorProps} />
+        <Editor {...params.editorProps} className={editorClassName} />
+        <Error {...params.errorProps} className={errorClassName} />
       </div>
     </React.Fragment>
   );


### PR DESCRIPTION
This PR allows for css customization of the three useView components.

## Background

There is currently no way to inject classes into this storybook add-on. `react-view` expects you to do it outside of `useView` which [accepts a single "className" property](https://github.com/uber/react-view/blob/master/src/types.ts#L49), but [doesn't export it](https://github.com/uber/react-view/blob/master/src/use-view.ts#L104-L115).